### PR TITLE
S3 bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arrow.patch
 Title: Patch Arrow Functions for Serialising SF Columns
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person(given = "Anthony", family = "North", role = c("aut", "cre"), email = "anthony.north@qfes.qld.gov.au"),
     person(given = "Miles", family = "McBain", role = c("ctb"), email = "miles.mcbain@qfes.qld.gov.au", comment = c(ORCID = "0000-0003-2865-2548")))
@@ -26,5 +26,5 @@ Suggests:
     roxyglobals (>= 0.2.1),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: 
+Remotes:
     anthonynorth/roxyglobals

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(decode_wkb,data.frame)
 S3method(decode_wkb,default)
+S3method(decode_wkb,sf)
 S3method(encode_wkb,data.frame)
 S3method(encode_wkb,default)
 export(decode_wkb)

--- a/R/codec.R
+++ b/R/codec.R
@@ -57,7 +57,6 @@ decode_wkb.default <- function(data) data
 #' @global where
 #' @export
 decode_wkb.data.frame <- function(data) {
-  print(class(data))
   is_sfc <- \(col) attr(col, "wkb") %||% FALSE
   from_wkb <- \(col) sf::st_as_sfc(col, crs = attr(col, "crs"))
 
@@ -67,6 +66,8 @@ decode_wkb.data.frame <- function(data) {
 
 #' @export
 decode_wkb.sf <- function(data) {
-  NextMethod() |>
-    sf::st_sf(sf_column_name = attr(data, "sf_column"))
+  data |>
+    drop_class("sf") |>
+    decode_wkb.data.frame() |>
+    add_class("sf")
 }

--- a/R/codec.R
+++ b/R/codec.R
@@ -57,9 +57,16 @@ decode_wkb.default <- function(data) data
 #' @global where
 #' @export
 decode_wkb.data.frame <- function(data) {
+  print(class(data))
   is_sfc <- \(col) attr(col, "wkb") %||% FALSE
   from_wkb <- \(col) sf::st_as_sfc(col, crs = attr(col, "crs"))
 
   data |>
     dplyr::mutate(dplyr::across(where(is_sfc), from_wkb))
+}
+
+#' @export
+decode_wkb.sf <- function(data) {
+  NextMethod() |>
+    sf::st_sf(sf_column_name = attr(data, "sf_column"))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,6 +10,9 @@ once <- function(fn) {
 }
 
 add_class <- \(obj, new_class) `class<-`(obj, c(new_class, class(obj)))
+drop_class <- \(obj, old_class) `class<-`(obj, setdiff(class(obj), old_class))
+set_class <- `class<-`
+
 set_attr <- `attr<-`
 
 `%||%` <- \(x, y) if (is.null(x)) y else x


### PR DESCRIPTION
Fixes the `mutate.sf` bug when calling `decode_wkb` for the first time. Dplyr throws an error inside dplyr_reconstruct.sf, which fails due to the sf columns not yet being decoded; a race condition. This problem solves itself after the first error, due to all relevant libs being attached (I think)

```
1: arrow.patch::decode_wkb(arrow::read_parquet("s3://qfesshiny/responses/oms_r
2: decode_wkb.data.frame(arrow::read_parquet("s3://qfesshiny/responses/oms_res
3: dplyr::mutate(data, dplyr::across(where(is_sfc), from_wkb))
4: mutate.data.frame(data, dplyr::across(where(is_sfc), from_wkb))
5: dplyr_col_modify(.data, cols)
6: dplyr_col_modify.data.frame(.data, cols)
7: dplyr_reconstruct(out, data)
8: dplyr_reconstruct_dispatch(data, template)
9: dplyr_reconstruct.sf(data, template)
10: st_precision(template)
11: st_precision.sf(template)
12: st_geometry(x)
13: st_geometry.sf(x)
```